### PR TITLE
Add AWS API Gateway deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.build/
+.bundle/
+vendor/bundle/

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Error responses use a structured JSON body:
 
 Supported requests must stay within a 100 year boundary from the request time.
 
+Successful responses are limited to 10,000 occurrences. Requests that would expand beyond that limit return `too_many_occurrences`.
+
 ### Development
 
 Use Ruby 3.0 or newer.
@@ -77,12 +79,22 @@ Requirements:
 - `zip`
 - AWS credentials with access to Lambda, API Gateway, CloudFormation, IAM, S3, and CloudWatch Logs
 
+The deployment creates AWS resources and may incur AWS costs. The default stack includes API Gateway throttling of 5 requests per second with a burst of 10, and Lambda reserved concurrency of 5 to cap runaway traffic.
+
 Deploy:
 
 ```sh
 export AWS_REGION=us-west-2
 export ARTIFACT_BUCKET=rrules-api-artifacts-us-west-2
 scripts/deploy_aws.sh
+```
+
+Optional limit overrides:
+
+```sh
+export API_THROTTLE_RATE_LIMIT=5
+export API_THROTTLE_BURST_LIMIT=10
+export LAMBDA_RESERVED_CONCURRENCY=5
 ```
 
 The deploy script prints the `ApiBaseUrl`, `RRuleExpandUrl`, and `HealthUrl` CloudFormation outputs. Use `RRuleExpandUrl` as the public API endpoint.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 ## Expand RRULEs via API
 
-Get individual occurrences of an RRULE directly via API (`api.rrules.com`). The API backend is deployed on AWS Lambda, and relies on the [ruby-rrule](https://github.com/square/ruby-rrule) gem.
+Get individual occurrences of an RRULE directly via API. The API backend is deployed on AWS Lambda behind API Gateway, and relies on the [ruby-rrule](https://github.com/square/ruby-rrule) gem.
+
+The production URL is an AWS-managed API Gateway URL:
+
+```text
+https://<api-id>.execute-api.<region>.amazonaws.com/prod
+```
 
 ```sh
-curl -X POST https://api.rrules.com/rrule_expand \
+curl -X POST https://<api-id>.execute-api.<region>.amazonaws.com/prod/rrule_expand \
   -H 'Content-Type: application/json' \
   -d '{"rrule":"FREQ=DAILY;COUNT=3","start_time":"2019-03-05 00:46:42 -0800","end_time":"2019-06-05 00:46:42 -0800"}'
 ```
@@ -60,6 +66,27 @@ bundle install
 bundle exec rspec
 ```
 
+### Deployment
+
+This project deploys to AWS Lambda and API Gateway HTTP API without a custom domain. The generated endpoint uses API Gateway's default `execute-api` hostname.
+
+Requirements:
+
+- AWS CLI v2
+- Docker
+- `zip`
+- AWS credentials with access to Lambda, API Gateway, CloudFormation, IAM, S3, and CloudWatch Logs
+
+Deploy:
+
+```sh
+export AWS_REGION=us-west-2
+export ARTIFACT_BUCKET=rrules-api-artifacts-us-west-2
+scripts/deploy_aws.sh
+```
+
+The deploy script prints the `ApiBaseUrl`, `RRuleExpandUrl`, and `HealthUrl` CloudFormation outputs. Use `RRuleExpandUrl` as the public API endpoint.
+
 ### Support or Contact
 
-Having trouble with the API? Please create an issue and I will do my best to be responsive, quickly. If you plan to hit the API with more than a couple thousand requests a day, please let me know first.
+Having trouble with the API? Please create an issue and I will do my best to be responsive. If you plan to hit the API with more than a couple thousand requests a day, please let me know first.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Requirements:
 
 The deployment creates AWS resources and may incur AWS costs. The default stack includes API Gateway throttling of 5 requests per second with a burst of 10, and Lambda reserved concurrency of 5 to cap runaway traffic.
 
+API Gateway owns CORS for the deployed API. The Lambda handler returns only application headers, which avoids duplicate CORS headers in real HTTP API responses.
+
 Deploy:
 
 ```sh

--- a/handler.rb
+++ b/handler.rb
@@ -15,12 +15,12 @@ BOUNDARY_SECONDS = (100 * 365.25 * 24 * 60 * 60).to_i
 class InvalidJsonBody < StandardError; end
 
 def router(event:, context:)
+  route_key = request_route_key(event || {})
   method = request_method(event || {})
   path = request_path(event || {})
 
-  return json_response(204, {}) if method == 'OPTIONS'
-  return health_check(event: event, context: context) if method == 'GET' && path == '/health'
-  return rrule_expand(event: event, context: context) if method == 'POST' && path == '/rrule_expand'
+  return health_check(event: event, context: context) if route_key == 'GET /health' || (method == 'GET' && path == '/health')
+  return rrule_expand(event: event, context: context) if route_key == 'POST /rrule_expand' || (method == 'POST' && path == '/rrule_expand')
 
   json_response(404, error: 'not_found', message: 'Route not found')
 end
@@ -86,6 +86,13 @@ def request_params(event)
   query_params.merge(body_params)
 end
 
+def request_route_key(event)
+  event['routeKey'] ||
+    event[:routeKey] ||
+    event.dig('requestContext', 'routeKey') ||
+    event.dig(:requestContext, :routeKey)
+end
+
 def request_method(event)
   event.dig('requestContext', 'http', 'method') ||
     event.dig(:requestContext, :http, :method) ||
@@ -94,10 +101,19 @@ def request_method(event)
 end
 
 def request_path(event)
-  event['rawPath'] ||
+  path = event['rawPath'] ||
     event[:rawPath] ||
     event['path'] ||
     event[:path]
+
+  strip_stage_prefix(path, event)
+end
+
+def strip_stage_prefix(path, event)
+  stage = event.dig('requestContext', 'stage') || event.dig(:requestContext, :stage)
+  return path if blank?(path) || blank?(stage) || stage == '$default'
+
+  path.sub(%r{\A/#{Regexp.escape(stage)}(?=/|\z)}, '')
 end
 
 def parse_body(event)
@@ -164,10 +180,7 @@ def json_response(status_code, payload)
   {
     statusCode: status_code,
     headers: {
-      'Content-Type' => 'application/json',
-      'Access-Control-Allow-Origin' => '*',
-      'Access-Control-Allow-Headers' => 'content-type',
-      'Access-Control-Allow-Methods' => 'GET,POST,OPTIONS'
+      'Content-Type' => 'application/json'
     },
     body: JSON.generate(payload)
   }

--- a/handler.rb
+++ b/handler.rb
@@ -8,6 +8,7 @@ require 'rrule'
 
 DEFAULT_TIME_ZONE = 'UTC'
 DEFAULT_END_TIME_SECONDS = 365 * 24 * 60 * 60
+MAX_OCCURRENCES = 10_000
 # Approximate range guard to keep recurrence expansion bounded.
 BOUNDARY_SECONDS = (100 * 365.25 * 24 * 60 * 60).to_i
 
@@ -52,7 +53,17 @@ def rrule_expand(event:, context:)
   end
 
   rule = RRule::Rule.new(params['rrule'], tzid: time_zone, dtstart: start_time)
-  occurrences = rule.between(start_time, end_time).map { |time| time.utc.iso8601 }
+  occurrences = rule.between(start_time, end_time, limit: MAX_OCCURRENCES + 1)
+
+  if occurrences.size > MAX_OCCURRENCES
+    return json_response(
+      422,
+      error: 'too_many_occurrences',
+      message: "RRULE expansion is limited to #{MAX_OCCURRENCES} occurrences"
+    )
+  end
+
+  occurrences = occurrences.map { |time| time.utc.iso8601 }
 
   json_response(200, message: 'ok', occurrences: occurrences)
 rescue JSON::ParserError

--- a/handler.rb
+++ b/handler.rb
@@ -13,6 +13,21 @@ BOUNDARY_SECONDS = (100 * 365.25 * 24 * 60 * 60).to_i
 
 class InvalidJsonBody < StandardError; end
 
+def router(event:, context:)
+  method = request_method(event || {})
+  path = request_path(event || {})
+
+  return json_response(204, {}) if method == 'OPTIONS'
+  return health_check(event: event, context: context) if method == 'GET' && path == '/health'
+  return rrule_expand(event: event, context: context) if method == 'POST' && path == '/rrule_expand'
+
+  json_response(404, error: 'not_found', message: 'Route not found')
+end
+
+def health_check(event:, context:)
+  json_response(200, message: 'ok')
+end
+
 def rrule_expand(event:, context:)
   params = request_params(event || {})
 
@@ -58,6 +73,20 @@ def request_params(event)
   body_params = parse_body(event)
 
   query_params.merge(body_params)
+end
+
+def request_method(event)
+  event.dig('requestContext', 'http', 'method') ||
+    event.dig(:requestContext, :http, :method) ||
+    event['httpMethod'] ||
+    event[:httpMethod]
+end
+
+def request_path(event)
+  event['rawPath'] ||
+    event[:rawPath] ||
+    event['path'] ||
+    event[:path]
 end
 
 def parse_body(event)
@@ -125,7 +154,9 @@ def json_response(status_code, payload)
     statusCode: status_code,
     headers: {
       'Content-Type' => 'application/json',
-      'Access-Control-Allow-Origin' => '*'
+      'Access-Control-Allow-Origin' => '*',
+      'Access-Control-Allow-Headers' => 'content-type',
+      'Access-Control-Allow-Methods' => 'GET,POST,OPTIONS'
     },
     body: JSON.generate(payload)
   }

--- a/index.md
+++ b/index.md
@@ -57,6 +57,8 @@ Error responses use a structured JSON body:
 
 Supported requests must stay within a 100 year boundary from the request time.
 
+Successful responses are limited to 10,000 occurrences. Requests that would expand beyond that limit return `too_many_occurrences`.
+
 ### Development
 
 Use Ruby 3.0 or newer.
@@ -77,12 +79,22 @@ Requirements:
 - `zip`
 - AWS credentials with access to Lambda, API Gateway, CloudFormation, IAM, S3, and CloudWatch Logs
 
+The deployment creates AWS resources and may incur AWS costs. The default stack includes API Gateway throttling of 5 requests per second with a burst of 10, and Lambda reserved concurrency of 5 to cap runaway traffic.
+
 Deploy:
 
 ```sh
 export AWS_REGION=us-west-2
 export ARTIFACT_BUCKET=rrules-api-artifacts-us-west-2
 scripts/deploy_aws.sh
+```
+
+Optional limit overrides:
+
+```sh
+export API_THROTTLE_RATE_LIMIT=5
+export API_THROTTLE_BURST_LIMIT=10
+export LAMBDA_RESERVED_CONCURRENCY=5
 ```
 
 The deploy script prints the `ApiBaseUrl`, `RRuleExpandUrl`, and `HealthUrl` CloudFormation outputs. Use `RRuleExpandUrl` as the public API endpoint.

--- a/index.md
+++ b/index.md
@@ -1,9 +1,15 @@
 ## Expand RRULEs via API
 
-Get individual occurrences of an RRULE directly via API (`api.rrules.com`). The API backend is deployed on AWS Lambda, and relies on the [ruby-rrule](https://github.com/square/ruby-rrule) gem.
+Get individual occurrences of an RRULE directly via API. The API backend is deployed on AWS Lambda behind API Gateway, and relies on the [ruby-rrule](https://github.com/square/ruby-rrule) gem.
+
+The production URL is an AWS-managed API Gateway URL:
+
+```text
+https://<api-id>.execute-api.<region>.amazonaws.com/prod
+```
 
 ```sh
-curl -X POST https://api.rrules.com/rrule_expand \
+curl -X POST https://<api-id>.execute-api.<region>.amazonaws.com/prod/rrule_expand \
   -H 'Content-Type: application/json' \
   -d '{"rrule":"FREQ=DAILY;COUNT=3","start_time":"2019-03-05 00:46:42 -0800","end_time":"2019-06-05 00:46:42 -0800"}'
 ```
@@ -60,6 +66,27 @@ bundle install
 bundle exec rspec
 ```
 
+### Deployment
+
+This project deploys to AWS Lambda and API Gateway HTTP API without a custom domain. The generated endpoint uses API Gateway's default `execute-api` hostname.
+
+Requirements:
+
+- AWS CLI v2
+- Docker
+- `zip`
+- AWS credentials with access to Lambda, API Gateway, CloudFormation, IAM, S3, and CloudWatch Logs
+
+Deploy:
+
+```sh
+export AWS_REGION=us-west-2
+export ARTIFACT_BUCKET=rrules-api-artifacts-us-west-2
+scripts/deploy_aws.sh
+```
+
+The deploy script prints the `ApiBaseUrl`, `RRuleExpandUrl`, and `HealthUrl` CloudFormation outputs. Use `RRuleExpandUrl` as the public API endpoint.
+
 ### Support or Contact
 
-Having trouble with the API? Please create an issue and I will do my best to be responsive, quickly. If you plan to hit the API with more than a couple thousand requests a day, please let me know first.
+Having trouble with the API? Please create an issue and I will do my best to be responsive. If you plan to hit the API with more than a couple thousand requests a day, please let me know first.

--- a/index.md
+++ b/index.md
@@ -81,6 +81,8 @@ Requirements:
 
 The deployment creates AWS resources and may incur AWS costs. The default stack includes API Gateway throttling of 5 requests per second with a burst of 10, and Lambda reserved concurrency of 5 to cap runaway traffic.
 
+API Gateway owns CORS for the deployed API. The Lambda handler returns only application headers, which avoids duplicate CORS headers in real HTTP API responses.
+
 Deploy:
 
 ```sh

--- a/infrastructure/cloudformation.yml
+++ b/infrastructure/cloudformation.yml
@@ -18,6 +18,21 @@ Parameters:
     AllowedValues:
       - ruby3.4
       - ruby3.3
+  LambdaReservedConcurrentExecutions:
+    Type: Number
+    Default: 5
+    MinValue: 1
+    Description: Maximum concurrent Lambda executions reserved for this API.
+  ApiThrottleBurstLimit:
+    Type: Number
+    Default: 10
+    MinValue: 1
+    Description: API Gateway burst request limit for the stage.
+  ApiThrottleRateLimit:
+    Type: Number
+    Default: 5
+    MinValue: 1
+    Description: API Gateway steady-state requests per second limit for the stage.
 
 Resources:
   FunctionRole:
@@ -48,6 +63,7 @@ Resources:
         S3Bucket: !Ref CodeS3Bucket
         S3Key: !Ref CodeS3Key
       MemorySize: 256
+      ReservedConcurrentExecutions: !Ref LambdaReservedConcurrentExecutions
       Timeout: 10
 
   FunctionLogGroup:
@@ -100,6 +116,9 @@ Resources:
       ApiId: !Ref HttpApi
       StageName: !Ref EnvironmentName
       AutoDeploy: true
+      DefaultRouteSettings:
+        ThrottlingBurstLimit: !Ref ApiThrottleBurstLimit
+        ThrottlingRateLimit: !Ref ApiThrottleRateLimit
 
   ApiInvokePermission:
     Type: AWS::Lambda::Permission

--- a/infrastructure/cloudformation.yml
+++ b/infrastructure/cloudformation.yml
@@ -1,0 +1,121 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: RRULE expansion API backed by Lambda and API Gateway HTTP API.
+
+Parameters:
+  ServiceName:
+    Type: String
+    Default: rrules-api
+  EnvironmentName:
+    Type: String
+    Default: prod
+  CodeS3Bucket:
+    Type: String
+  CodeS3Key:
+    Type: String
+  LambdaRuntime:
+    Type: String
+    Default: ruby3.4
+    AllowedValues:
+      - ruby3.4
+      - ruby3.3
+
+Resources:
+  FunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub '${ServiceName}-${EnvironmentName}-lambda-role'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+
+  RRuleFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub '${ServiceName}-${EnvironmentName}'
+      Description: Expands RFC 5545 RRULEs.
+      Runtime: !Ref LambdaRuntime
+      Architectures:
+        - x86_64
+      Handler: handler.router
+      Role: !GetAtt FunctionRole.Arn
+      Code:
+        S3Bucket: !Ref CodeS3Bucket
+        S3Key: !Ref CodeS3Key
+      MemorySize: 256
+      Timeout: 10
+
+  FunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub '/aws/lambda/${RRuleFunction}'
+      RetentionInDays: 30
+
+  HttpApi:
+    Type: AWS::ApiGatewayV2::Api
+    Properties:
+      Name: !Sub '${ServiceName}-${EnvironmentName}'
+      ProtocolType: HTTP
+      CorsConfiguration:
+        AllowHeaders:
+          - content-type
+        AllowMethods:
+          - GET
+          - POST
+          - OPTIONS
+        AllowOrigins:
+          - '*'
+
+  LambdaIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: !Ref HttpApi
+      IntegrationType: AWS_PROXY
+      IntegrationUri: !Sub 'arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${RRuleFunction.Arn}/invocations'
+      IntegrationMethod: POST
+      PayloadFormatVersion: '2.0'
+
+  RRuleRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /rrule_expand
+      Target: !Sub 'integrations/${LambdaIntegration}'
+
+  HealthRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: GET /health
+      Target: !Sub 'integrations/${LambdaIntegration}'
+
+  ApiStage:
+    Type: AWS::ApiGatewayV2::Stage
+    Properties:
+      ApiId: !Ref HttpApi
+      StageName: !Ref EnvironmentName
+      AutoDeploy: true
+
+  ApiInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref RRuleFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${HttpApi}/*/*'
+
+Outputs:
+  ApiBaseUrl:
+    Description: AWS-managed API Gateway base URL.
+    Value: !Sub 'https://${HttpApi}.execute-api.${AWS::Region}.amazonaws.com/${EnvironmentName}'
+  RRuleExpandUrl:
+    Description: RRULE expansion endpoint.
+    Value: !Sub 'https://${HttpApi}.execute-api.${AWS::Region}.amazonaws.com/${EnvironmentName}/rrule_expand'
+  HealthUrl:
+    Description: Health check endpoint.
+    Value: !Sub 'https://${HttpApi}.execute-api.${AWS::Region}.amazonaws.com/${EnvironmentName}/health'

--- a/scripts/deploy_aws.sh
+++ b/scripts/deploy_aws.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STACK_NAME="${STACK_NAME:-rrules-api-prod}"
+SERVICE_NAME="${SERVICE_NAME:-rrules-api}"
+ENVIRONMENT_NAME="${ENVIRONMENT_NAME:-prod}"
+AWS_REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-us-west-2}}"
+ARTIFACT_BUCKET="${ARTIFACT_BUCKET:-}"
+
+if [[ -z "${ARTIFACT_BUCKET}" ]]; then
+  echo "ARTIFACT_BUCKET is required. Example: ARTIFACT_BUCKET=my-lambda-artifacts-${AWS_REGION} scripts/deploy_aws.sh" >&2
+  exit 1
+fi
+
+ZIP_PATH="$("${ROOT_DIR}/scripts/package_lambda.sh")"
+ZIP_KEY="${SERVICE_NAME}/${ENVIRONMENT_NAME}/rrules-api-$(shasum -a 256 "${ZIP_PATH}" | awk '{print $1}').zip"
+
+if ! aws s3api head-bucket --bucket "${ARTIFACT_BUCKET}" --region "${AWS_REGION}" >/dev/null 2>&1; then
+  if [[ "${AWS_REGION}" == "us-east-1" ]]; then
+    aws s3api create-bucket --bucket "${ARTIFACT_BUCKET}" --region "${AWS_REGION}"
+  else
+    aws s3api create-bucket \
+      --bucket "${ARTIFACT_BUCKET}" \
+      --region "${AWS_REGION}" \
+      --create-bucket-configuration "LocationConstraint=${AWS_REGION}"
+  fi
+fi
+
+aws s3 cp "${ZIP_PATH}" "s3://${ARTIFACT_BUCKET}/${ZIP_KEY}" --region "${AWS_REGION}"
+
+aws cloudformation deploy \
+  --region "${AWS_REGION}" \
+  --stack-name "${STACK_NAME}" \
+  --template-file "${ROOT_DIR}/infrastructure/cloudformation.yml" \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --parameter-overrides \
+    ServiceName="${SERVICE_NAME}" \
+    EnvironmentName="${ENVIRONMENT_NAME}" \
+    CodeS3Bucket="${ARTIFACT_BUCKET}" \
+    CodeS3Key="${ZIP_KEY}"
+
+aws cloudformation describe-stacks \
+  --region "${AWS_REGION}" \
+  --stack-name "${STACK_NAME}" \
+  --query 'Stacks[0].Outputs' \
+  --output table

--- a/scripts/deploy_aws.sh
+++ b/scripts/deploy_aws.sh
@@ -7,6 +7,9 @@ SERVICE_NAME="${SERVICE_NAME:-rrules-api}"
 ENVIRONMENT_NAME="${ENVIRONMENT_NAME:-prod}"
 AWS_REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-us-west-2}}"
 ARTIFACT_BUCKET="${ARTIFACT_BUCKET:-}"
+LAMBDA_RESERVED_CONCURRENCY="${LAMBDA_RESERVED_CONCURRENCY:-5}"
+API_THROTTLE_BURST_LIMIT="${API_THROTTLE_BURST_LIMIT:-10}"
+API_THROTTLE_RATE_LIMIT="${API_THROTTLE_RATE_LIMIT:-5}"
 
 if [[ -z "${ARTIFACT_BUCKET}" ]]; then
   echo "ARTIFACT_BUCKET is required. Example: ARTIFACT_BUCKET=my-lambda-artifacts-${AWS_REGION} scripts/deploy_aws.sh" >&2
@@ -38,7 +41,10 @@ aws cloudformation deploy \
     ServiceName="${SERVICE_NAME}" \
     EnvironmentName="${ENVIRONMENT_NAME}" \
     CodeS3Bucket="${ARTIFACT_BUCKET}" \
-    CodeS3Key="${ZIP_KEY}"
+    CodeS3Key="${ZIP_KEY}" \
+    LambdaReservedConcurrentExecutions="${LAMBDA_RESERVED_CONCURRENCY}" \
+    ApiThrottleBurstLimit="${API_THROTTLE_BURST_LIMIT}" \
+    ApiThrottleRateLimit="${API_THROTTLE_RATE_LIMIT}"
 
 aws cloudformation describe-stacks \
   --region "${AWS_REGION}" \

--- a/scripts/package_lambda.sh
+++ b/scripts/package_lambda.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="${ROOT_DIR}/.build/lambda"
+ZIP_PATH="${ROOT_DIR}/.build/rrules-api.zip"
+RUBY_IMAGE="${RUBY_IMAGE:-public.ecr.aws/lambda/ruby:3.4}"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "Docker is required to build Lambda dependencies for Amazon Linux." >&2
+  exit 1
+fi
+
+if ! command -v zip >/dev/null 2>&1; then
+  echo "zip is required to create the Lambda deployment package." >&2
+  exit 1
+fi
+
+rm -rf "${BUILD_DIR}"
+mkdir -p "${BUILD_DIR}"
+
+cp "${ROOT_DIR}/handler.rb" "${BUILD_DIR}/"
+cp "${ROOT_DIR}/Gemfile" "${BUILD_DIR}/"
+cp "${ROOT_DIR}/Gemfile.lock" "${BUILD_DIR}/"
+
+docker run --rm \
+  --platform linux/amd64 \
+  -v "${BUILD_DIR}:/var/task" \
+  -w /var/task \
+  "${RUBY_IMAGE}" \
+  /bin/bash -lc "dnf install -y gcc gcc-c++ make && bundle config set --local path vendor/bundle && bundle config set --local without test && bundle install && rm -rf vendor/bundle/ruby/*/cache"
+
+rm -f "${ZIP_PATH}"
+(cd "${BUILD_DIR}" && zip -qr "${ZIP_PATH}" .)
+
+echo "${ZIP_PATH}"

--- a/spec/handler_spec.rb
+++ b/spec/handler_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe '#router' do
 
   it 'routes RRULE expansion requests' do
     response = routed_response_for(
-      'requestContext' => { 'http' => { 'method' => 'POST' } },
+      'routeKey' => 'POST /rrule_expand',
+      'requestContext' => { 'http' => { 'method' => 'POST' }, 'stage' => 'prod' },
       'rawPath' => '/rrule_expand',
       'headers' => { 'Content-Type' => 'application/json' },
       'body' => JSON.generate(
@@ -33,6 +34,32 @@ RSpec.describe '#router' do
 
     expect(response[:statusCode]).to eq(200)
     expect(response[:body]['occurrences']).to eq(['2019-03-05T08:46:42Z'])
+  end
+
+  it 'routes named-stage HTTP API events using routeKey' do
+    response = routed_response_for(
+      'routeKey' => 'POST /rrule_expand',
+      'requestContext' => { 'http' => { 'method' => 'POST' }, 'stage' => 'prod' },
+      'rawPath' => '/prod/rrule_expand',
+      'headers' => { 'Content-Type' => 'application/json' },
+      'body' => JSON.generate(
+        'rrule' => 'FREQ=DAILY;COUNT=1',
+        'start_time' => '2019-03-05 00:46:42 -0800'
+      )
+    )
+
+    expect(response[:statusCode]).to eq(200)
+    expect(response[:body]['occurrences']).to eq(['2019-03-05T08:46:42Z'])
+  end
+
+  it 'strips named-stage prefixes when falling back to path routing' do
+    response = routed_response_for(
+      'requestContext' => { 'http' => { 'method' => 'GET' }, 'stage' => 'prod' },
+      'rawPath' => '/prod/health'
+    )
+
+    expect(response[:statusCode]).to eq(200)
+    expect(response[:body]).to eq('message' => 'ok')
   end
 
   it 'returns not found for unknown routes' do
@@ -46,6 +73,19 @@ RSpec.describe '#router' do
       'error' => 'not_found',
       'message' => 'Route not found'
     )
+  end
+
+  it 'does not return app-level CORS headers' do
+    response = router(
+      event: {
+        'routeKey' => 'GET /health',
+        'requestContext' => { 'http' => { 'method' => 'GET' } },
+        'rawPath' => '/health'
+      },
+      context: nil
+    )
+
+    expect(response[:headers]).to eq('Content-Type' => 'application/json')
   end
 end
 

--- a/spec/handler_spec.rb
+++ b/spec/handler_spec.rb
@@ -303,4 +303,23 @@ RSpec.describe '#rrule_expand' do
       'message' => 'start_time or end_time cannot be outside the supported 100 year boundary'
     )
   end
+
+  it 'returns structured errors when expansion exceeds the occurrence limit' do
+    stub_const('MAX_OCCURRENCES', 2)
+
+    response = response_for(
+      'headers' => { 'Content-Type' => 'application/json' },
+      'body' => JSON.generate(
+        'rrule' => 'FREQ=DAILY;COUNT=3',
+        'start_time' => '2019-03-05 00:46:42 -0800',
+        'end_time' => '2019-03-10 00:46:42 -0800'
+      )
+    )
+
+    expect(response[:statusCode]).to eq(422)
+    expect(response[:body]).to eq(
+      'error' => 'too_many_occurrences',
+      'message' => 'RRULE expansion is limited to 2 occurrences'
+    )
+  end
 end

--- a/spec/handler_spec.rb
+++ b/spec/handler_spec.rb
@@ -4,6 +4,51 @@ require 'uri'
 
 require_relative '../handler'
 
+RSpec.describe '#router' do
+  def routed_response_for(event)
+    response = router(event: event, context: nil)
+    response.merge(body: JSON.parse(response[:body]))
+  end
+
+  it 'routes health checks' do
+    response = routed_response_for(
+      'requestContext' => { 'http' => { 'method' => 'GET' } },
+      'rawPath' => '/health'
+    )
+
+    expect(response[:statusCode]).to eq(200)
+    expect(response[:body]).to eq('message' => 'ok')
+  end
+
+  it 'routes RRULE expansion requests' do
+    response = routed_response_for(
+      'requestContext' => { 'http' => { 'method' => 'POST' } },
+      'rawPath' => '/rrule_expand',
+      'headers' => { 'Content-Type' => 'application/json' },
+      'body' => JSON.generate(
+        'rrule' => 'FREQ=DAILY;COUNT=1',
+        'start_time' => '2019-03-05 00:46:42 -0800'
+      )
+    )
+
+    expect(response[:statusCode]).to eq(200)
+    expect(response[:body]['occurrences']).to eq(['2019-03-05T08:46:42Z'])
+  end
+
+  it 'returns not found for unknown routes' do
+    response = routed_response_for(
+      'requestContext' => { 'http' => { 'method' => 'GET' } },
+      'rawPath' => '/missing'
+    )
+
+    expect(response[:statusCode]).to eq(404)
+    expect(response[:body]).to eq(
+      'error' => 'not_found',
+      'message' => 'Route not found'
+    )
+  end
+end
+
 RSpec.describe '#rrule_expand' do
   def response_for(event)
     response = rrule_expand(event: event, context: nil)


### PR DESCRIPTION
## Summary

- Add a router Lambda entrypoint for API Gateway HTTP API routes
- Add `GET /health` and `POST /rrule_expand` routing
- Add CloudFormation for Lambda, API Gateway HTTP API, IAM role, permissions, log retention, API throttling, and Lambda reserved concurrency
- Add scripts to package Lambda dependencies in an AWS Ruby 3.4 container and deploy via AWS CLI
- Update README/site docs to use the AWS-managed `execute-api` endpoint pattern instead of the lost `rrules.com` domain

## Public API Safety

- RRULE expansions are capped at 10,000 occurrences per response
- API Gateway defaults to 5 requests/second with a burst of 10
- Lambda reserved concurrency defaults to 5
- README documents AWS resource creation and possible AWS costs

## HTTP API Correctness

- Router prefers API Gateway HTTP API `routeKey` instead of relying only on `rawPath`
- Path fallback strips named-stage prefixes such as `/prod`
- CORS is owned by API Gateway only; Lambda responses return application headers only to avoid duplicate CORS headers

## Deployment Notes

This uses API Gateway's default hostname, so no custom domain or ACM certificate is needed. The deployment script requires AWS credentials, Docker, zip, and an S3 artifact bucket name.

```sh
export AWS_REGION=us-west-2
export ARTIFACT_BUCKET=rrules-api-artifacts-us-west-2
scripts/deploy_aws.sh
```

Optional limit overrides:

```sh
export API_THROTTLE_RATE_LIMIT=5
export API_THROTTLE_BURST_LIMIT=10
export LAMBDA_RESERVED_CONCURRENCY=5
```

## Tests

- `BUNDLE_IGNORE_CONFIG=1 bundle exec rspec --format documentation`
- `bash -n scripts/package_lambda.sh scripts/deploy_aws.sh`
- parsed `infrastructure/cloudformation.yml` locally

## Not Yet Verified

I could not run a real deployment from this machine because AWS credentials and Docker are not configured locally.
